### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine
+
+RUN apk update && apk upgrade
+
+RUN mkdir -p /app/node_modules && chown -R node:node /app
+
+WORKDIR /app
+
+COPY --chown=node:node package.json yarn.lock ./
+
+USER node
+
+RUN yarn install
+
+COPY --chown=node:node public public
+COPY --chown=node:node views views
+COPY --chown=node:node app.js ./
+
+EXPOSE 3000
+
+CMD ["/bin/sh", "-c", "npm start 2>&1 | tee log.txt"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install dependencies
 
 Start dev server
 
-    yarn start
+    yarn watch
 
 Be aware that the authentication cookie used by default uses the [secure attribute](https://en.wikipedia.org/wiki/Secure_cookie) thus the demo will only work when connecting via
 
@@ -48,9 +48,20 @@ Be aware that the authentication cookie used by default uses the [secure attribu
 
 ## Production
 
+Start with `npm start`, or use one of the strategies below
+
+### PM2
+
 Install with [pm2](https://pm2.keymetrics.io/)
 
     pm2 start ./app.js --name auth
+
+### Docker
+
+```
+sudo docker build -t auth-server .
+sudo docker run -it -p 3000:3000 -e AUTH_PASSWORD=test -e AUTH_TOKEN_SECRET=verysecret auth-server
+```
 
 ## Example NGINX conf
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "morgan": "^1.10.0"
   },
   "scripts": {
-    "start": "nodemon app.js"
+    "start": "node app.js",
+    "watch": "nodemon app.js"
   },
   "name": "auth-server",
   "version": "1.0.0",


### PR DESCRIPTION
Hi there,

I needed this for my homelab but everything runs inside Docker so I made some modifications and thought to share.

As I don't want to run nodemon in production I modified the start scripts to move `start` to `watch`, and `start` to just run the thing. I hope this doesn't mess anything up for PM2 (I've never used that). Please have a look.

Cheers

