### PR TITLE
Cookie overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine
+
+RUN apk update && apk upgrade
+
+RUN mkdir -p /app/node_modules && chown -R node:node /app
+
+WORKDIR /app
+
+COPY --chown=node:node package.json yarn.lock ./
+
+USER node
+
+RUN yarn install
+
+COPY --chown=node:node public public
+COPY --chown=node:node views views
+COPY --chown=node:node app.js ./
+
+EXPOSE 3000
+
+CMD ["/bin/sh", "-c", "npm start 2>&1 | tee log.txt"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install dependencies
 
 Start dev server
 
-    yarn start
+    yarn watch
 
 Be aware that the authentication cookie used by default uses the [secure attribute](https://en.wikipedia.org/wiki/Secure_cookie) thus the demo will only work when connecting via
 
@@ -48,9 +48,20 @@ Be aware that the authentication cookie used by default uses the [secure attribu
 
 ## Production
 
+Start with `npm start`, or use one of the strategies below
+
+### PM2
+
 Install with [pm2](https://pm2.keymetrics.io/)
 
     pm2 start ./app.js --name auth
+
+### Docker
+
+```
+sudo docker build -t auth-server .
+sudo docker run -it -p 3000:3000 -e AUTH_PASSWORD=test -e AUTH_TOKEN_SECRET=verysecret auth-server
+```
 
 ## Example NGINX conf
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "express": "^4.17.1",
     "express-rate-limit": "^5.5.0",
     "jsonwebtoken": "^8.5.1",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "nocache": "^4.0.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "morgan": "^1.10.0"
   },
   "scripts": {
-    "start": "nodemon app.js"
+    "start": "node app.js",
+    "watch": "nodemon app.js"
   },
   "name": "auth-server",
   "version": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,6 +442,11 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
+nocache@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/nocache/-/nocache-4.0.0.tgz#d6c6f34bee4600f63f852dccfeb29c9a96cf85c0"
+  integrity sha512-AntnTbmKZvNYIsTVPPwv7dfZdAfo/6H/2ZlZACK66NAOQtIApxkB/6pf/c+s+ACW8vemGJzUCyVTssrzNUK6yQ==
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"


### PR DESCRIPTION
This PR is based on the other PR, please merge that one before reviewing this.

Here I've added two new environment variables:
`EXPIRY_DAYS`  can now be configured (still defaults to 7)
`AUTH_COOKIE_OVERRIDES` presents the option to override cookie settings such as path, domain, etc.

I needed this as the auth is running on a subdomain of its target.

I also added a nocache to the whole thing. It is running behind a proxy and sometimes the proxy would start caching things.